### PR TITLE
GET requests for rocks and types will now return data

### DIFF
--- a/rockapi/fixtures/rocks.json
+++ b/rockapi/fixtures/rocks.json
@@ -1,0 +1,32 @@
+[
+    {
+        "model": "rockapi.rock",
+        "pk": 1,
+        "fields": {
+            "user": 1,
+            "type": 3,
+            "name": "Ernestina",
+            "weight": 1.3
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 2,
+        "fields": {
+            "user": 1,
+            "type": 1,
+            "name": "Orpha",
+            "weight": 0.5
+        }
+    },
+    {
+        "model": "rockapi.rock",
+        "pk": 3,
+        "fields": {
+            "user": 1,
+            "type": 5,
+            "name": "Sasha",
+            "weight": 0.29
+        }
+    }
+]

--- a/rockapi/fixtures/types.json
+++ b/rockapi/fixtures/types.json
@@ -1,0 +1,37 @@
+[
+    {
+        "model": "rockapi.type",
+        "pk": 1,
+        "fields": {
+            "label": "Metamorphic"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 2,
+        "fields": {
+            "label": "Igneous"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 3,
+        "fields": {
+            "label": "Sedimentary"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 4,
+        "fields": {
+            "label": "Shale"
+        }
+    },
+    {
+        "model": "rockapi.type",
+        "pk": 5,
+        "fields": {
+            "label": "Basalt"
+        }
+    }
+]


### PR DESCRIPTION
I created a fixtures directory where I added a json file for both rocks and types and added some initial data. 

Supported routes
- `/types`
- `/rocks`

## Steps to test
### All Rocks
1. Pull down the database-fixtures branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Request http://localhost:8000/rocks and verify that you get an array of rocks in the response, and that each one has the following keys on it
    - id
    - name
    - weight
5. Also verify that the response code is 200

### All Types
1. Request http://localhost:8000/types and verify that you get an array of types in the response, and that each one has the following keys on it
    - id
    - label
2. Also verify that the response code is 200