### PR TITLE
Added delete a single rock functionality

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -32,6 +32,25 @@ class RockView(ViewSet):
         except Exception as ex:
             return Response({"reason": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
 
+    def destroy(self, request, pk=None):
+        """Handle DELETE requests for a single rock
+
+        Returns:
+            Response -- 200, 404, or 500 status code
+        """
+        try:
+            rock = Rock.objects.get(pk=pk)
+            rock.delete()
+            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+        except Rock.DoesNotExist as ex:
+            return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)
+
+        except Exception as ex:
+            return Response(
+                {"message": ex.args[0]}, status=status.HTTP_500_INTERNAL_SERVER_ERROR
+            )
+
     def list(self, request):
         """Handle GET requests for all rocks
 

--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -30,7 +30,9 @@ class RockView(ViewSet):
             serializer = RockSerializer(rock, many=False)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         except Exception as ex:
-            return Response({"reason": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {"response": ex.args[0]}, status=status.HTTP_400_BAD_REQUEST
+            )
 
     def destroy(self, request, pk=None):
         """Handle DELETE requests for a single rock
@@ -40,8 +42,15 @@ class RockView(ViewSet):
         """
         try:
             rock = Rock.objects.get(pk=pk)
-            rock.delete()
-            return Response(None, status=status.HTTP_204_NO_CONTENT)
+
+            if rock.user.id == request.auth.user.id:
+                rock.delete()
+                return Response(None, status=status.HTTP_204_NO_CONTENT)
+            else:
+                return Response(
+                    {"message": "You do not own that rock"},
+                    status=status.HTTP_403_FORBIDDEN,
+                )
 
         except Rock.DoesNotExist as ex:
             return Response({"message": ex.args[0]}, status=status.HTTP_404_NOT_FOUND)


### PR DESCRIPTION
I added a `delete` method to `RockView` class.

Supported routes
`/rocks/n` DELETE a rock from the database

## Steps to test
### Delete Rock (If the user owns the rock)
1. Pull down the `delete_rocks` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Change method to DELETE for `http://localhost:8000/rocks/n` where n is the id of the rock you want to delete
5. Once you send your DELETE, verify that the response code is 204

### If owner doesn't own the rock
1. When user tries to delete a rock that doesn't belong to them then they will receive a 403 response code