### PR TITLE
added route to show only the user's rocks

### DIFF
--- a/rockapi/views/rock_view.py
+++ b/rockapi/views/rock_view.py
@@ -38,7 +38,7 @@ class RockView(ViewSet):
         """Handle DELETE requests for a single rock
 
         Returns:
-            Response -- 200, 404, or 500 status code
+            Response -- 204, 403, 404, or 500 status code
         """
         try:
             rock = Rock.objects.get(pk=pk)
@@ -66,8 +66,18 @@ class RockView(ViewSet):
         Returns:
             Response -- JSON serialized array
         """
+        # Get query string parameter
+        owner_only = self.request.query_params.get("owner", None)
+
         try:
+            # Start with all rows
             rocks = Rock.objects.all()
+
+            # If `?owner=current` is in the URL
+            if owner_only is not None and owner_only == "current":
+                # Filter to only the current user's rocks
+                rocks = rocks.filter(user=request.auth.user)
+
             serializer = RockSerializer(rocks, many=True)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except Exception as ex:

--- a/rockapi/views/type_view.py
+++ b/rockapi/views/type_view.py
@@ -3,7 +3,7 @@ from django.http import HttpResponseServerError
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework import serializers, status
-from rockapi.models import Type
+from rockapi.models import Type,Rock
 
 
 class TypeView(ViewSet):
@@ -32,12 +32,26 @@ class TypeView(ViewSet):
         return Response(serialized.data, status=status.HTTP_200_OK)
 
 
+class RocksSerializer(serializers.ModelSerializer):
+    """JSON serializer for rocks"""
+    class Meta:
+        model = Rock
+        fields = (
+            "id",
+            "name",
+            "weight",
+        )
+
+
 class TypeSerializer(serializers.ModelSerializer):
     """JSON serializer for types"""
+
+    rocks = RocksSerializer(many=True)
 
     class Meta:
         model = Type
         fields = (
             "id",
             "label",
+            "rocks",
         )

--- a/rockapi/views/type_view.py
+++ b/rockapi/views/type_view.py
@@ -37,7 +37,6 @@ class RocksSerializer(serializers.ModelSerializer):
     class Meta:
         model = Rock
         fields = (
-            "id",
             "name",
             "weight",
         )


### PR DESCRIPTION
I added a `filter()` method to my `list` method inside `RockView` class
I also added `RocksSerializer` to `TypeView` class

Supported routes
`/rocks?owner=current` Will return all rock information for only the rocks that the user created
`/types` Will return all the type information with all the rocks listed as an array of objects on `rocks:`

## Steps to test
### RockView
1. Pull down the `user_rocks` branch and switch to it
2. If your debugger is running, restart it
3. Open Postman
4. Request `http://localhost:8000/rocks?owner=current` and verify that you get an array of the current user's rocks in the response, and that each one has the following keys on it
    - id
    - name
    - weight
    - user 
        - first_name
        - last_name
    - type
        - label
6. Also verify that the response code is 200

### TypeView
1. Request `http://localhost:8000/types` and verify that you get an array of the type objects in the response, and that each one has the following keys on it
    - id
    - label
    - rocks 
        - name
        - weight
2. Also verify that the response code is 200